### PR TITLE
casting obj to str to prevent obj vs str comparison

### DIFF
--- a/classify.py
+++ b/classify.py
@@ -40,7 +40,7 @@ for i in range(0,HAPLOTYPES):
 # now score read to chose a haplotype
 #we process fasta
 for i in range(HAPLOTYPES,len(sys.argv)):
-   recs = [ (rec.name, rec.seq) for rec in SeqIO.parse(open(sys.argv[i]), "fasta")]
+   recs = [ (rec.name, str(rec.seq)) for rec in SeqIO.parse(open(sys.argv[i]), "fasta")]
    for name, seq in recs:
       readHap = ""
       readHapCount = 0


### PR DESCRIPTION
We recommend casting the rec.seq into a string. Although rec.seq can be sliced or operate like string, the comparison of this Obj to the corresponding string actually return False. For rc kmer, this is fine because the reverse_complement returns string. However, any kmers that were returned from get_cannonical as original kmer will not be able to match with hapCounts. Consequentially, the kmers that can contribute to the classification of reads were roughly reduced by half. 
