### PR TITLE
fixed bug : A read contains same number of kmers from hap0 and hap1 

### DIFF
--- a/classify.py
+++ b/classify.py
@@ -67,7 +67,7 @@ for i in range(HAPLOTYPES,len(sys.argv)):
       for i in range(0, HAPLOTYPES):
          if i in hapCounts:
             tot+=hapCounts[i]
-            if hapCounts[i] > 0 and hapCounts[i] < readHapCount and hapCounts[i] > secondBest:
+            if hapCounts[i] > 0 and hapCounts[i] <= readHapCount and hapCounts[i] > secondBest:
                secondBest = hapCounts[i]
 
             if hapCounts[i] > 0 and hapCounts[i] > readHapCount:


### PR DESCRIPTION
BUG : If a read contains same number of kmers from hap0 and hap1 ,  classify.py will detect it as hap0.